### PR TITLE
Add unionid/domain lookup endpoint

### DIFF
--- a/htyuc_models/src/models.rs
+++ b/htyuc_models/src/models.rs
@@ -322,6 +322,26 @@ impl HtyUser {
         }
     }
 
+    pub fn find_opt_by_union_id(
+        id_union: &str,
+        conn: &mut PgConnection,
+    ) -> anyhow::Result<Option<HtyUser>> {
+        debug!("find_opt_by_union_id -> id_union: {:?}", id_union);
+
+        if id_union.is_empty() {
+            return Err(anyhow!(HtyErr {
+                code: HtyErrCode::DbErr,
+                reason: Some("find_opt_by_union_id -> `id_union` can't be NULL!".to_string()),
+            }));
+        }
+
+        use crate::schema::hty_users::dsl::*;
+        Ok(hty_users
+            .filter(union_id.eq(id_union))
+            .first::<HtyUser>(conn)
+            .optional()?)
+    }
+
     pub fn find_by_mobile(
         in_mobile: &str,
         conn: &mut PgConnection,


### PR DESCRIPTION
## Summary
- add GET `/api/v1/uc/find_user_by_unionid_and_domain` that reads the unionid query and host header without auth checks
- return user enabled/registration status for the current host using an optional unionid lookup helper
- add an optional unionid lookup helper on `HtyUser` for non-error union id queries

## Testing
- cargo check -p htyuc

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69352bc7d2908326b5ba8ce838c2dffa)